### PR TITLE
Change versioning for ingressauthgenerator

### DIFF
--- a/example/diary-chart/requirements.yaml
+++ b/example/diary-chart/requirements.yaml
@@ -8,5 +8,5 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
 
 - name: ingressauthgenerator
-  version: 0.0.1
+  version: 0.*-0
   repository:  http://kubernetes-charts.banzaicloud.com/


### PR DESCRIPTION
I'm following https://banzaicloud.com/blog/ingress-auth/

To build dependencies for this I received this error log:

```
$ helm dependency build .
Hang tight while we grab the latest from your chart repositories...
...Unable to get an update from the "local" chart repository (http://127.0.0.1:8879/charts):
	Get http://127.0.0.1:8879/charts/index.yaml: dial tcp 127.0.0.1:8879: connect: connection refused
...Successfully got an update from the "banzaicloud" chart repository
...Successfully got an update from the "stable" chart repository
Update Complete.
Error: Can't get a valid version for repositories traefik, ghost, ingressauthgenerator. Try changing the version constraint in requirements.yaml
```

On `requirements.yaml` I changed the versioning for ingressauthgenerator based on a similar issue that I found elsewhere.

Then was able to build the project..